### PR TITLE
base.html: bugfix for not always being passed JSON data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-wedsite',
-    version='0.0.1',
+    version='0.0.2',
     packages=find_packages(),
     include_package_data=True,
     license="GPLv3",

--- a/wedsite/templates/wedding/blocks/base.html
+++ b/wedsite/templates/wedding/blocks/base.html
@@ -27,8 +27,13 @@
 <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}" />
 
 <!-- Favicons -->
-<link rel="icon" type="image/vnd.microsoft.icon"
+{% if favicon|length > 0 %}
+  <link rel="icon" type="image/vnd.microsoft.icon"
     sizes="32x32 48x48" href="{% static favicon %}?v=2">
+{% else %}
+  <link rel="icon" type="image/vnd.microsoft.icon"
+    sizes="32x32 48x48" href="{% static 'images/favicons/favicon-heart.ico' %}?v=2">
+{% endif %}
 
 <style>
 {% block style %}
@@ -77,7 +82,7 @@
             href="#">Travel<span class="caret"></span></a>
           <ul class="dropdown-menu">
             <li><a href="{% url 'travel' %}">Travel & Lodging</a></li>
-            <li><a href="{% url 'explore' %}">{{ explore.title }}</a></li>
+            <li><a href="{% url 'explore' %}">Explore the Area</a></li>
           </ul>
         </li> <!--end travel dropdown-->
         <li><a href="{% url 'rsvp' %}">RSVP</a></li>


### PR DESCRIPTION
The registration template currently doesn't get passed the JSON
data. This is something that should eventually be fixed. The
favicon was reliant on the data and was causing an exception
when favicon wasn't supplied. Add an if/else into the base template
to either use the passed favicon or fall back to the default heart.

Also fix a similar issue with the explore header, as we can't
guarantee we'll be passed the explore title. Same goes
for the gride/broom initials, but when those are none they
just don't show up which is fine.

Also bump the bugfix version